### PR TITLE
Add PHP 8 support

### DIFF
--- a/virion.yml
+++ b/virion.yml
@@ -3,4 +3,4 @@ version: 2.1.0
 api: [3.0.0]
 antigen: JackMD\UpdateNotifier
 authors: [JackMD, Sandertv]
-php: [7.2]
+php: [7.2, 8.0]


### PR DESCRIPTION
Production versions of PocketMine-MP API 3 are planned to require PHP versions of 8.0 or newer very soon. This pull request adds support for PocketMine-MP servers running on PHP 8.0 or newer.