### PR TITLE
Fix for when poggit goes down

### DIFF
--- a/src/JackMD/UpdateNotifier/task/UpdateNotifyTask.php
+++ b/src/JackMD/UpdateNotifier/task/UpdateNotifyTask.php
@@ -55,13 +55,15 @@ class UpdateNotifyTask extends AsyncTask{
 		$api = "";
 		if($json !== null){
 			$releases = json_decode($json->getBody(), true);
-			foreach($releases as $release){
-				if(version_compare($highestVersion, $release["version"], ">=")){
-					continue;
+			if($releases !== null) { /* Poggit is Down! */
+				foreach($releases as $release){
+					if(version_compare($highestVersion, $release["version"], ">=")){
+						continue;
+					}
+					$highestVersion = $release["version"];
+					$artifactUrl = $release["artifact_url"];
+					$api = $release["api"][0]["from"] . " - " . $release["api"][0]["to"];
 				}
-				$highestVersion = $release["version"];
-				$artifactUrl = $release["artifact_url"];
-				$api = $release["api"][0]["from"] . " - " . $release["api"][0]["to"];
 			}
 		}
 


### PR DESCRIPTION
ErrorException: "foreach() argument must be of type array|object, null given"